### PR TITLE
Feature: Add 'run_through' argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Program parameters:
     --no_check                Disable program flow check
 -e, --elf <FILE>              Use external elf file w/o compilation step
     --trace                   Trace and analyse program w/o fault injection
+-r, --run-through             Don't stop on first successful fault injection
 -h, --help                    Print help
 -V, --version                 Print version
 

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -14,12 +14,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.sample_size(10);
     group.bench_function("single attack", |b| {
         b.iter(|| {
-            let _ = attack.single(2000, false, false, &mut vec!["glitch".to_string()].iter());
+            let _ = attack.single(2000, false, false, &mut vec!["glitch".to_string()].iter(), false);
         })
     });
     group.bench_function("double attack", |b| {
         b.iter(|| {
-            let _ = attack.double(2000, false, false, &mut vec!["glitch".to_string()].iter());
+            let _ = attack.double(2000, false, false, &mut vec!["glitch".to_string()].iter(), false);
         })
     });
 }

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -14,12 +14,24 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.sample_size(10);
     group.bench_function("single attack", |b| {
         b.iter(|| {
-            let _ = attack.single(2000, false, false, &mut vec!["glitch".to_string()].iter(), false);
+            let _ = attack.single(
+                2000,
+                false,
+                false,
+                &mut vec!["glitch".to_string()].iter(),
+                false,
+            );
         })
     });
     group.bench_function("double attack", |b| {
         b.iter(|| {
-            let _ = attack.double(2000, false, false, &mut vec!["glitch".to_string()].iter(), false);
+            let _ = attack.double(
+                2000,
+                false,
+                false,
+                &mut vec!["glitch".to_string()].iter(),
+                false,
+            );
         })
     });
 }

--- a/src/fault_attacks/mod.rs
+++ b/src/fault_attacks/mod.rs
@@ -105,38 +105,35 @@ impl FaultAttacks {
         deep_analysis: bool,
         prograss_bar: bool,
         groups: &mut Iter<String>,
-        run_through : bool,
+        run_through: bool,
     ) -> Result<(bool, usize), String> {
         let lists = get_fault_lists(groups); // Get all faults of all lists
         let mut any_success = false; // Track if any fault was successful
-        let mut total_attacks = 0;   // Track total number of attacks
-    
+
         for list in lists {
             // Iterate over all faults in the list
             for fault in list {
                 // Get fault type
                 let fault = get_fault_from(&fault).unwrap();
-    
+
                 // Run simulation with fault
-                let fault_data = 
+                let fault_data =
                     self.fault_simulation(cycles, &[fault.clone()], deep_analysis, prograss_bar)?;
-    
+
                 if !fault_data.is_empty() {
                     any_success = true;
-                    for data in fault_data { // Push each inner Vec<FaultData>
+                    for data in fault_data {
+                        // Push each inner Vec<FaultData>
                         self.fault_data.push(data);
                     }
                     if !run_through {
-                        return Ok((any_success, total_attacks + 1));
+                        return Ok((any_success, self.count_sum));
                     }
                 }
-    
-                total_attacks += 1; 
             }
         }
-        Ok((any_success, total_attacks))
+        Ok((any_success, self.count_sum))
     }
-    
 
     /// Run double glitch attacks
     ///
@@ -148,12 +145,11 @@ impl FaultAttacks {
         deep_analysis: bool,
         prograss_bar: bool,
         groups: &mut Iter<String>,
-        run_through : bool,
+        run_through: bool,
     ) -> Result<(bool, usize), String> {
         let lists = get_fault_lists(groups); // Get all faults of all lists
         let mut any_success = false; // Track if any fault was successful
-        let mut total_attacks = 0;   // Track total number of attacks
-    
+
         for list in lists {
             // Iterate over all faults in the list
             let iter = iproduct!(list.clone(), list).map(|(a, b)| (a, b));
@@ -161,24 +157,23 @@ impl FaultAttacks {
             for t in iter {
                 let fault1 = get_fault_from(&t.0).unwrap();
                 let fault2 = get_fault_from(&t.1).unwrap();
-    
+
                 let fault_data =
                     self.fault_simulation(cycles, &[fault1, fault2], deep_analysis, prograss_bar)?;
-    
+
                 if !fault_data.is_empty() {
                     any_success = true;
-                    for data in fault_data { // Push each inner Vec<FaultData>
+                    for data in fault_data {
+                        // Push each inner Vec<FaultData>
                         self.fault_data.push(data);
                     }
                     if !run_through {
-                        return Ok((any_success, total_attacks + 1));
+                        return Ok((any_success, self.count_sum));
                     }
                 }
-    
-                total_attacks += 1; 
             }
         }
-        Ok((any_success, total_attacks))
+        Ok((any_success, self.count_sum))
     }
 
     pub fn fault_simulation(

--- a/src/fault_attacks/mod.rs
+++ b/src/fault_attacks/mod.rs
@@ -105,28 +105,38 @@ impl FaultAttacks {
         deep_analysis: bool,
         prograss_bar: bool,
         groups: &mut Iter<String>,
+        run_through : bool,
     ) -> Result<(bool, usize), String> {
         let lists = get_fault_lists(groups); // Get all faults of all lists
-                                             // Iterate over all lists
+        let mut any_success = false; // Track if any fault was successful
+        let mut total_attacks = 0;   // Track total number of attacks
+    
         for list in lists {
             // Iterate over all faults in the list
             for fault in list {
                 // Get fault type
                 let fault = get_fault_from(&fault).unwrap();
+    
                 // Run simulation with fault
-                self.fault_data =
+                let fault_data = 
                     self.fault_simulation(cycles, &[fault.clone()], deep_analysis, prograss_bar)?;
-
-                if !self.fault_data.is_empty() {
-                    break;
+    
+                if !fault_data.is_empty() {
+                    any_success = true;
+                    for data in fault_data { // Push each inner Vec<FaultData>
+                        self.fault_data.push(data);
+                    }
+                    if !run_through {
+                        return Ok((any_success, total_attacks + 1));
+                    }
                 }
-            }
-            if !self.fault_data.is_empty() {
-                break;
+    
+                total_attacks += 1; 
             }
         }
-        Ok((!self.fault_data.is_empty(), self.count_sum))
+        Ok((any_success, total_attacks))
     }
+    
 
     /// Run double glitch attacks
     ///
@@ -138,9 +148,12 @@ impl FaultAttacks {
         deep_analysis: bool,
         prograss_bar: bool,
         groups: &mut Iter<String>,
+        run_through : bool,
     ) -> Result<(bool, usize), String> {
         let lists = get_fault_lists(groups); // Get all faults of all lists
-                                             // Iterate over all lists
+        let mut any_success = false; // Track if any fault was successful
+        let mut total_attacks = 0;   // Track total number of attacks
+    
         for list in lists {
             // Iterate over all faults in the list
             let iter = iproduct!(list.clone(), list).map(|(a, b)| (a, b));
@@ -148,19 +161,24 @@ impl FaultAttacks {
             for t in iter {
                 let fault1 = get_fault_from(&t.0).unwrap();
                 let fault2 = get_fault_from(&t.1).unwrap();
-
-                self.fault_data =
+    
+                let fault_data =
                     self.fault_simulation(cycles, &[fault1, fault2], deep_analysis, prograss_bar)?;
-
-                if !self.fault_data.is_empty() {
-                    break;
+    
+                if !fault_data.is_empty() {
+                    any_success = true;
+                    for data in fault_data { // Push each inner Vec<FaultData>
+                        self.fault_data.push(data);
+                    }
+                    if !run_through {
+                        return Ok((any_success, total_attacks + 1));
+                    }
                 }
-            }
-            if !self.fault_data.is_empty() {
-                break;
+    
+                total_attacks += 1; 
             }
         }
-        Ok((!self.fault_data.is_empty(), self.count_sum))
+        Ok((any_success, total_attacks))
     }
 
     pub fn fault_simulation(

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ struct Args {
     /// Disable program flow check
     #[arg(long, default_value_t = false)]
     no_check: bool,
+
+    /// Don't stop on first successful fault injection
+    #[arg(short, long, default_value_t = false)]
+    run_through : bool,
 }
 
 /// Program to simulate fault injections on ARMv8-M processors (e.g. M33)
@@ -113,8 +117,13 @@ fn main() -> Result<(), String> {
         let mut class = args.class.iter();
         match class.next().as_ref().map(|s| s.as_str()) {
             Some("all") | None => {
-                if !attack_sim
-                    .single(args.max_instructions, args.deep_analysis, true, &mut class)?
+                if !attack_sim.single(
+                        args.max_instructions, 
+                        args.deep_analysis, 
+                        true, 
+                        &mut class, 
+                        args.run_through 
+                    )?
                     .0
                 {
                     attack_sim.double(
@@ -122,14 +131,26 @@ fn main() -> Result<(), String> {
                         args.deep_analysis,
                         true,
                         &mut class,
+                        args.run_through 
                     )?;
                 }
             }
             Some("single") => {
-                attack_sim.single(args.max_instructions, args.deep_analysis, true, &mut class)?;
+                attack_sim.single(
+                    args.max_instructions,
+                    args.deep_analysis,
+                    true,
+                    &mut class,
+                    args.run_through 
+                )?;
             }
             Some("double") => {
-                attack_sim.double(args.max_instructions, args.deep_analysis, true, &mut class)?;
+                attack_sim.double(
+                    args.max_instructions,
+                    args.deep_analysis,
+                    true,
+                    &mut class,
+                    args.run_through )?;
             }
             _ => println!("Unknown attack class!"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ struct Args {
 
     /// Don't stop on first successful fault injection
     #[arg(short, long, default_value_t = false)]
-    run_through : bool,
+    run_through: bool,
 }
 
 /// Program to simulate fault injections on ARMv8-M processors (e.g. M33)
@@ -117,12 +117,13 @@ fn main() -> Result<(), String> {
         let mut class = args.class.iter();
         match class.next().as_ref().map(|s| s.as_str()) {
             Some("all") | None => {
-                if !attack_sim.single(
-                        args.max_instructions, 
-                        args.deep_analysis, 
-                        true, 
-                        &mut class, 
-                        args.run_through 
+                if !attack_sim
+                    .single(
+                        args.max_instructions,
+                        args.deep_analysis,
+                        true,
+                        &mut class,
+                        args.run_through,
                     )?
                     .0
                 {
@@ -131,7 +132,7 @@ fn main() -> Result<(), String> {
                         args.deep_analysis,
                         true,
                         &mut class,
-                        args.run_through 
+                        args.run_through,
                     )?;
                 }
             }
@@ -141,7 +142,7 @@ fn main() -> Result<(), String> {
                     args.deep_analysis,
                     true,
                     &mut class,
-                    args.run_through 
+                    args.run_through,
                 )?;
             }
             Some("double") => {
@@ -150,7 +151,8 @@ fn main() -> Result<(), String> {
                     args.deep_analysis,
                     true,
                     &mut class,
-                    args.run_through )?;
+                    args.run_through,
+                )?;
             }
             _ => println!("Unknown attack class!"),
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,14 +14,14 @@ fn run_single_glitch() {
     let vec = vec!["glitch".to_string()];
     assert_eq!(
         (true, 35),
-        attack.single(2000, false, false, &mut vec.iter()).unwrap()
+        attack.single(2000, false, false, &mut vec.iter(), false).unwrap()
     );
     // Load victim data for attack simulation
     let mut attack = FaultAttacks::new(std::path::PathBuf::from("tests/bin/victim_4.elf")).unwrap();
     // Result is (success: bool, number_of_attacks: usize)
     assert_eq!(
         (false, 376),
-        attack.single(2000, false, false, &mut vec.iter()).unwrap()
+        attack.single(2000, false, false, &mut vec.iter(), false).unwrap()
     );
 }
 
@@ -38,14 +38,14 @@ fn run_double_glitch() {
     let vec = vec!["glitch".to_string()];
     assert_eq!(
         (false, 22808),
-        attack.double(2000, false, false, &mut vec.iter()).unwrap()
+        attack.double(2000, false, false, &mut vec.iter(), false).unwrap()
     );
     let mut attack = FaultAttacks::new(std::path::PathBuf::from("tests/bin/victim_3.elf")).unwrap();
     // Result is (success: bool, number_of_attacks: usize)
     let vec = vec!["regbf".to_string()];
     assert_eq!(
         (true, 6916),
-        attack.double(2000, false, false, &mut vec.iter()).unwrap()
+        attack.double(2000, false, false, &mut vec.iter(), false).unwrap()
     );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,14 +14,18 @@ fn run_single_glitch() {
     let vec = vec!["glitch".to_string()];
     assert_eq!(
         (true, 35),
-        attack.single(2000, false, false, &mut vec.iter(), false).unwrap()
+        attack
+            .single(2000, false, false, &mut vec.iter(), false)
+            .unwrap()
     );
     // Load victim data for attack simulation
     let mut attack = FaultAttacks::new(std::path::PathBuf::from("tests/bin/victim_4.elf")).unwrap();
     // Result is (success: bool, number_of_attacks: usize)
     assert_eq!(
         (false, 376),
-        attack.single(2000, false, false, &mut vec.iter(), false).unwrap()
+        attack
+            .single(2000, false, false, &mut vec.iter(), false)
+            .unwrap()
     );
 }
 
@@ -38,14 +42,18 @@ fn run_double_glitch() {
     let vec = vec!["glitch".to_string()];
     assert_eq!(
         (false, 22808),
-        attack.double(2000, false, false, &mut vec.iter(), false).unwrap()
+        attack
+            .double(2000, false, false, &mut vec.iter(), false)
+            .unwrap()
     );
     let mut attack = FaultAttacks::new(std::path::PathBuf::from("tests/bin/victim_3.elf")).unwrap();
     // Result is (success: bool, number_of_attacks: usize)
     let vec = vec!["regbf".to_string()];
     assert_eq!(
         (true, 6916),
-        attack.double(2000, false, false, &mut vec.iter(), false).unwrap()
+        attack
+            .double(2000, false, false, &mut vec.iter(), false)
+            .unwrap()
     );
 }
 


### PR DESCRIPTION
This feature introduces a new `-r --run_through` flag, providing the option to either stop on the first successful fault injection or to continue running through all specified fault models. 
The default behavior remains.