### PR TITLE
Custom failure and success conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ CFLAGS_LD = -N -Wl,--build-id=none -g -gdwarf -Os -Wno-unused-but-set-variable \
 - `make` toolchain
 
 **Ghidra Trace Visualization**
-- Ghidra 11.3 with PyGhidra mode.
+- Ghidra 11.3 or newer with PyGhidra mode.
 
 ## Usage
 
@@ -121,6 +121,8 @@ CFLAGS_LD = -N -Wl,--build-id=none -g -gdwarf -Os -Wno-unused-but-set-variable \
 | `-e, --elf <FILE>`             | Use external elf file w/o compilation step |
 | `--trace`                      | Trace and analyse program w/o fault injection |
 | `-r, --run-through`            | Don't stop on first successful fault injection |
+| `--success-addresses [<SUCCESS_ADDRESSES>...]` | List of memory addresses that indicate success when accessed Format: --success-addresses 0x8000123 0x8000456 |
+| `--failure-addresses [<FAILURE_ADDRESSES>...]` | List of memory addresses that indicate failure when accessed Format: --failure-addresses 0x8000789 0x8000abc |
 | `-h, --help`                   | Print help |
 | `-V, --version`                | Print version |
 
@@ -146,7 +148,7 @@ The Ghidra script you created enhances the visualization of the trace output gen
 
 **Usage:**
 
-1.  Ensure Ghidra 11.3 is installed and running in PyGhidra mode as described in the [Ghidra Installation Guide](https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_11.3_build/GhidraDocs/InstallationGuide.md#pyghidra-mode).
+1.  Ensure Ghidra 11.3 or newer is installed and running in PyGhidra mode as described in the [Ghidra Installation Guide](https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_11.3_build/GhidraDocs/InstallationGuide.md#pyghidra-mode).
 2. Start the script in Ghidra.
 3. Paste the trace output from the simulation.
 4. Observe the executed instructions highlighted in green and the faulted instruction in red.

--- a/src/fault_attacks/mod.rs
+++ b/src/fault_attacks/mod.rs
@@ -105,7 +105,8 @@ impl FaultAttacks {
             let handle = thread::spawn(move || {
                 // Wait for workload
                 // Create a new simulation instance
-                let mut simulation = Control::new(&file, false, success_addrs.clone(), failure_addrs.clone());
+                let mut simulation =
+                    Control::new(&file, false, success_addrs.clone(), failure_addrs.clone());
                 // Loop until the workload receiver is closed
                 while let Ok(msg) = receiver.recv() {
                     let WorkloadMessage {
@@ -118,9 +119,14 @@ impl FaultAttacks {
                     // Todo: Do error handling
                     match run_type {
                         RunType::RecordFullTrace | RunType::RecordTrace => {
-                            match Control::new(&file, false, success_addrs.clone(), failure_addrs.clone())
-                                .run_with_faults(cycles, run_type, deep_analysis, &records)
-                                .unwrap()
+                            match Control::new(
+                                &file,
+                                false,
+                                success_addrs.clone(),
+                                failure_addrs.clone(),
+                            )
+                            .run_with_faults(cycles, run_type, deep_analysis, &records)
+                            .unwrap()
                             {
                                 Data::Trace(trace) => trace_sender
                                     .unwrap()
@@ -277,7 +283,12 @@ impl FaultAttacks {
     /// * `Ok(())` if successful, otherwise `Err(String)`.
     pub fn check_for_correct_behavior(&self) -> Result<(), String> {
         // Get trace data from negative run
-        let mut simulation = Control::new(&self.file_data, true, self.success_addresses.clone(), self.failure_addresses.clone());
+        let mut simulation = Control::new(
+            &self.file_data,
+            true,
+            self.success_addresses.clone(),
+            self.failure_addresses.clone(),
+        );
         simulation.check_program(self.cycles)
     }
 

--- a/src/fault_attacks/mod.rs
+++ b/src/fault_attacks/mod.rs
@@ -42,6 +42,8 @@ pub struct FaultAttacks {
     fault_response_receiver: Receiver<Vec<FaultData>>,
     handles: Vec<thread::JoinHandle<()>>,
     work_load_counter: std::sync::Arc<std::sync::Mutex<usize>>,
+    success_addresses: Vec<u64>,
+    failure_addresses: Vec<u64>,
 }
 
 impl FaultAttacks {
@@ -54,6 +56,8 @@ impl FaultAttacks {
     /// * `deep_analysis` - Whether to perform deep analysis.
     /// * `run_through` - Whether to run through all faults.
     /// * `threads` - Number of threads to use (must be > 0).
+    /// * `success_addresses` - List of memory addresses that indicate success when accessed.
+    /// * `failure_addresses` - List of memory addresses that indicate failure when accessed.
     ///
     /// # Returns
     ///
@@ -64,6 +68,8 @@ impl FaultAttacks {
         deep_analysis: bool,
         run_through: bool,
         threads: usize,
+        success_addresses: Vec<u64>,
+        failure_addresses: Vec<u64>,
     ) -> Result<Self, String> {
         // Load victim data
         let file_data: ElfFile = ElfFile::new(path)?;
@@ -94,10 +100,12 @@ impl FaultAttacks {
             let receiver = workload_receiver.clone();
             let fault_sender = fault_response_sender.clone();
             let workload_counter = Arc::clone(&work_load_counter);
+            let success_addrs = success_addresses.clone();
+            let failure_addrs = failure_addresses.clone();
             let handle = thread::spawn(move || {
                 // Wait for workload
                 // Create a new simulation instance
-                let mut simulation = Control::new(&file, false);
+                let mut simulation = Control::new(&file, false, success_addrs.clone(), failure_addrs.clone());
                 // Loop until the workload receiver is closed
                 while let Ok(msg) = receiver.recv() {
                     let WorkloadMessage {
@@ -110,7 +118,7 @@ impl FaultAttacks {
                     // Todo: Do error handling
                     match run_type {
                         RunType::RecordFullTrace | RunType::RecordTrace => {
-                            match Control::new(&file, false)
+                            match Control::new(&file, false, success_addrs.clone(), failure_addrs.clone())
                                 .run_with_faults(cycles, run_type, deep_analysis, &records)
                                 .unwrap()
                             {
@@ -155,6 +163,8 @@ impl FaultAttacks {
             fault_response_receiver,
             handles,
             work_load_counter,
+            success_addresses,
+            failure_addresses,
         })
     }
 
@@ -267,7 +277,7 @@ impl FaultAttacks {
     /// * `Ok(())` if successful, otherwise `Err(String)`.
     pub fn check_for_correct_behavior(&self) -> Result<(), String> {
         // Get trace data from negative run
-        let mut simulation = Control::new(&self.file_data, true);
+        let mut simulation = Control::new(&self.file_data, true, self.success_addresses.clone(), self.failure_addresses.clone());
         simulation.check_program(self.cycles)
     }
 

--- a/src/simulation/cpu/callback.rs
+++ b/src/simulation/cpu/callback.rs
@@ -60,7 +60,7 @@ pub fn hook_custom_addresses_callback(emu: &mut Unicorn<CpuState>, address: u64,
         emu.emu_stop().expect("failed to stop");
         return;
     }
-    
+
     // Check for failure addresses
     if emu_data.failure_addresses.contains(&address) {
         emu.get_data_mut().state = RunState::Failed;

--- a/src/simulation/cpu/callback.rs
+++ b/src/simulation/cpu/callback.rs
@@ -48,6 +48,28 @@ pub fn mmio_auth_write_callback(
     true
 }
 
+/// Dedicated hook for custom success/failure address monitoring
+/// This hook only checks for user-defined success and failure addresses
+pub fn hook_custom_addresses_callback(emu: &mut Unicorn<CpuState>, address: u64, _size: u32) {
+    let emu_data = emu.get_data();
+
+    // Check for success addresses
+    if emu_data.success_addresses.contains(&address) {
+        emu.get_data_mut().state = RunState::Success;
+        debug!("Custom success address reached: 0x{:x}", address);
+        emu.emu_stop().expect("failed to stop");
+        return;
+    }
+    
+    // Check for failure addresses
+    if emu_data.failure_addresses.contains(&address) {
+        emu.get_data_mut().state = RunState::Failed;
+        debug!("Custom failure address reached: 0x{:x}", address);
+        emu.emu_stop().expect("failed to stop");
+        return;
+    }
+}
+
 /// Callback for serial mem IO write access
 ///
 /// This IO write displays printed messages

--- a/src/simulation/cpu/mod.rs
+++ b/src/simulation/cpu/mod.rs
@@ -7,8 +7,8 @@ use crate::simulation::{
 mod callback;
 
 use callback::{
-    hook_code_callback, hook_code_decision_activation_callback, mmio_auth_write_callback,
-    mmio_serial_write_callback, hook_custom_addresses_callback,
+    hook_code_callback, hook_code_decision_activation_callback, hook_custom_addresses_callback,
+    mmio_auth_write_callback, mmio_serial_write_callback,
 };
 
 use unicorn_engine::unicorn_const::uc_error;
@@ -84,7 +84,11 @@ impl<'a> Cpu<'a> {
     /// # Returns
     ///
     /// * `Self` - Returns a `Cpu` instance.
-    pub fn new(file_data: &'a ElfFile, success_addresses: Vec<u64>, failure_addresses: Vec<u64>) -> Self {
+    pub fn new(
+        file_data: &'a ElfFile,
+        success_addresses: Vec<u64>,
+        failure_addresses: Vec<u64>,
+    ) -> Self {
         // Setup platform -> ARMv8-m.base
         let emu = Unicorn::new_with_data(
             Arch::ARM,
@@ -193,9 +197,10 @@ impl<'a> Cpu<'a> {
                 )
                 .expect("failed to set decision_activation code hook");
         }
-        
+
         // Set up code hooks for custom success/failure addresses (if any provided)
-        let has_custom_addresses = !self.emu.get_data().success_addresses.is_empty() || !self.emu.get_data().failure_addresses.is_empty();
+        let has_custom_addresses = !self.emu.get_data().success_addresses.is_empty()
+            || !self.emu.get_data().failure_addresses.is_empty();
         if has_custom_addresses {
             // Add code hook for the entire program to check for custom addresses
             let program_data = &self.emu.get_data().file_data.program_data[0];

--- a/src/simulation/cpu/mod.rs
+++ b/src/simulation/cpu/mod.rs
@@ -8,7 +8,7 @@ mod callback;
 
 use callback::{
     hook_code_callback, hook_code_decision_activation_callback, mmio_auth_write_callback,
-    mmio_serial_write_callback,
+    mmio_serial_write_callback, hook_custom_addresses_callback,
 };
 
 use unicorn_engine::unicorn_const::uc_error;
@@ -68,6 +68,8 @@ struct CpuState<'a> {
     trace_data: Vec<TraceRecord>,
     fault_data: Vec<FaultData>,
     file_data: &'a ElfFile,
+    success_addresses: Vec<u64>,
+    failure_addresses: Vec<u64>,
 }
 
 impl<'a> Cpu<'a> {
@@ -76,11 +78,13 @@ impl<'a> Cpu<'a> {
     /// # Arguments
     ///
     /// * `file_data` - The ELF file data.
+    /// * `success_addresses` - List of memory addresses that indicate success when executed.
+    /// * `failure_addresses` - List of memory addresses that indicate failure when executed.
     ///
     /// # Returns
     ///
     /// * `Self` - Returns a `Cpu` instance.
-    pub fn new(file_data: &'a ElfFile) -> Self {
+    pub fn new(file_data: &'a ElfFile, success_addresses: Vec<u64>, failure_addresses: Vec<u64>) -> Self {
         // Setup platform -> ARMv8-m.base
         let emu = Unicorn::new_with_data(
             Arch::ARM,
@@ -94,6 +98,8 @@ impl<'a> Cpu<'a> {
                 trace_data: Vec::new(),
                 fault_data: Vec::new(),
                 file_data,
+                success_addresses,
+                failure_addresses,
             },
         )
         .expect("failed to initialize Unicorn instance");
@@ -187,14 +193,30 @@ impl<'a> Cpu<'a> {
                 )
                 .expect("failed to set decision_activation code hook");
         }
-        self.emu
-            .add_mem_hook(
-                HookType::MEM_WRITE,
-                AUTH_BASE,
-                AUTH_BASE + 4,
-                mmio_auth_write_callback,
-            )
-            .expect("failed to set memory hook");
+        
+        // Set up code hooks for custom success/failure addresses (if any provided)
+        let has_custom_addresses = !self.emu.get_data().success_addresses.is_empty() || !self.emu.get_data().failure_addresses.is_empty();
+        if has_custom_addresses {
+            // Add code hook for the entire program to check for custom addresses
+            let program_data = &self.emu.get_data().file_data.program_data[0];
+            self.emu
+                .add_code_hook(
+                    program_data.0.p_paddr,
+                    program_data.0.p_paddr + program_data.0.p_memsz,
+                    hook_custom_addresses_callback,
+                )
+                .expect("failed to set custom address code hook");
+        } else {
+            // Only set up the MMIO hook when NOT using custom addresses
+            self.emu
+                .add_mem_hook(
+                    HookType::MEM_WRITE,
+                    AUTH_BASE,
+                    AUTH_BASE + 4,
+                    mmio_auth_write_callback,
+                )
+                .expect("failed to set memory hook");
+        }
     }
 
     /// Setup memory mapping, stack, io mapping

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -36,13 +36,15 @@ impl<'a> Control<'a> {
     ///
     /// * `program_data` - A reference to the ELF file containing the program data.
     /// * `decision_activation_active` - A boolean indicating whether decision activation is enabled.
+    /// * `success_addresses` - List of memory addresses that indicate success when executed.
+    /// * `failure_addresses` - List of memory addresses that indicate failure when executed.
     ///
     /// # Returns
     ///
     /// * `Self` - Returns a new `Control` instance.
-    pub fn new(program_data: &'a ElfFile, decision_activation_active: bool) -> Self {
+    pub fn new(program_data: &'a ElfFile, decision_activation_active: bool, success_addresses: Vec<u64>, failure_addresses: Vec<u64>) -> Self {
         // Setup cpu emulation
-        let mut emu = Cpu::new(program_data);
+        let mut emu = Cpu::new(program_data, success_addresses, failure_addresses);
         // Cpu setup
         emu.setup_mmio();
         emu.setup_breakpoints(decision_activation_active);

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -42,7 +42,12 @@ impl<'a> Control<'a> {
     /// # Returns
     ///
     /// * `Self` - Returns a new `Control` instance.
-    pub fn new(program_data: &'a ElfFile, decision_activation_active: bool, success_addresses: Vec<u64>, failure_addresses: Vec<u64>) -> Self {
+    pub fn new(
+        program_data: &'a ElfFile,
+        decision_activation_active: bool,
+        success_addresses: Vec<u64>,
+        failure_addresses: Vec<u64>,
+    ) -> Self {
         // Setup cpu emulation
         let mut emu = Cpu::new(program_data, success_addresses, failure_addresses);
         // Cpu setup

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,6 +14,8 @@ fn run_single_glitch() {
         false,
         false,
         15,
+        vec![], // success_addresses
+        vec![], // failure_addresses
     )
     .unwrap();
     // Result is (success: bool, number_of_attacks: usize)
@@ -26,6 +28,8 @@ fn run_single_glitch() {
         false,
         false,
         15,
+        vec![], // success_addresses
+        vec![], // failure_addresses
     )
     .unwrap();
     // Result is (success: bool, number_of_attacks: usize)
@@ -45,6 +49,8 @@ fn run_double_glitch() {
         false,
         false,
         15,
+        vec![], // success_addresses
+        vec![], // failure_addresses
     )
     .unwrap();
     // Result is (false: bool, number_of_attacks: usize)
@@ -56,6 +62,8 @@ fn run_double_glitch() {
         false,
         false,
         15,
+        vec![], // success_addresses
+        vec![], // failure_addresses
     )
     .unwrap();
     // Result is (success: bool, number_of_attacks: usize)
@@ -76,6 +84,8 @@ fn run_fault_simulation_one_glitch() {
         false,
         false,
         15,
+        vec![], // success_addresses
+        vec![], // failure_addresses
     )
     .unwrap();
     // Result is Vec<Vec<FaultData>>
@@ -111,6 +121,8 @@ fn run_fault_simulation_two_glitches() {
         false,
         false,
         15,
+        vec![], // success_addresses
+        vec![], // failure_addresses
     )
     .unwrap();
 


### PR DESCRIPTION
This Pull request is in preparation for further implementations I am currently planning.

It allows to set addresses as success and failure conditions instead of compiling a test program with `__SET_SIM_SUCCESS` and `__SET_SIM_FAILED`

I implemented two additional arguments for that
```
      --success-addresses [<SUCCESS_ADDRESSES>...]
          List of memory addresses that indicate success when accessed Format: --success-addresses 0x8000123 0x8000456
      --failure-addresses [<FAILURE_ADDRESSES>...]
          List of memory addresses that indicate failure when accessed Format: --failure-addresses 0x8000789 0x8000abc
```

When these arguments are given, a new `hook_custom_addresses_callback` is used instead of  `mmio_auth_write_callback`

I'm not so happy about the fact the success_addrs and failure_addrs are now passed as functions paramters to many functions... This probably could be improved.