### PR TITLE
Add JSON config integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ build = "build.rs"
 mml = { git = 'https://github.com/adjivas/ml.git', branch = 'master' }
 
 [dependencies]
-unicorn-engine = "2.1.3"
+unicorn-engine = "=2.1.3"
 elf = "0.7.0"
 log = "0.4.17"
 env_logger = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,5 @@ colored = "2.1.0"
 crossbeam-channel = "0.5.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+assert_cmd = "2.0.17"
+predicates = "3.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,5 @@ addr2line = "0.21.0"
 regex = "1.10.5"
 colored = "2.1.0"
 crossbeam-channel = "0.5.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ CFLAGS_LD = -N -Wl,--build-id=none -g -gdwarf -Os -Wno-unused-but-set-variable \
   - `rayon`
   - `itertools`
   - `clap`
+  - `serde`
+  - `serder_json`
 
 **Compiler Toolchain**
 - `gcc-arm-none-eabi` compiler toolchain
@@ -107,8 +109,12 @@ CFLAGS_LD = -N -Wl,--build-id=none -g -gdwarf -Os -Wno-unused-but-set-variable \
 
 ## Usage
 
+You can configure the simulator using either command-line arguments or a JSON config file.  
+CLI arguments always override values from the config file.
+
 ### Command-Line Options
 | Flag/Option                    | Description |
+| `-c, --config <CONFIG>`             | Load configuration from JSON file |
 |--------------------------------|-------------|
 | `-t, --threads <THREADS>`      | Number of threads started in parallel [default: 1]. "-t 0" activate full thread usage |
 | `-n, --no-compilation`         | Suppress re-compilation of target program |
@@ -128,19 +134,41 @@ CFLAGS_LD = -N -Wl,--build-id=none -g -gdwarf -Os -Wno-unused-but-set-variable \
 
 ### Examples
 
-1. **Single glitch attack with trace analysis:**
+1. **Single glitch attack with trace analysis (CLI):**
    ```bash
    cargo run -- --class single glitch --analysis
    ```  
 
-2. **Double attack (glitch + register flood) on custom ELF:**
+2. **Single glitch attack with trace analysis (JSON config):**
+   Create a file (e.g., `example.json`):
+   ```json
+   {
+     "class": ["single", "glitch"],
+     "analysis": true
+   }
+   ```
+   Run with:
+   ```bash
+   cargo run -- --config example.json
+   ```
+
+3. **Mixing CLI and JSON:**
+   ```bash
+   cargo run -- --config example.json --analysis false
+   ```
+
+4. **Double attack (glitch + register flood) on custom ELF:**
    ```bash
    cargo run -- --class double glitch regfld --elf tests/bin/victim.elf -t 4
    ```
-3. **Running a fault sequence with register bit-flip and glitch:**
+
+5. **Running a fault sequence with register bit-flip and glitch:**
    ```bash
    cargo run -- --faults regbf_r1_0100 glitch_1
    ```
+
+**Hex Addresses:**  
+For address fields, you can use either numbers or hex strings (e.g., `"0x08000496"`) in your JSON config.
 
 ## Ghidra Visualization
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ where
             A: de::SeqAccess<'de>,
         {
             let mut addresses = Vec::new();
-            
+
             while let Some(value) = seq.next_element::<serde_json::Value>()? {
                 match value {
                     serde_json::Value::String(s) => {
@@ -58,7 +58,7 @@ where
                     _ => return Err(de::Error::custom("Address must be a string or number")),
                 }
             }
-            
+
             Ok(addresses)
         }
     }
@@ -99,16 +99,19 @@ struct Config {
 
 impl Config {
     // Keep defaults in sync with CLI defaults
-    fn default_threads() -> usize { 15 }
-    fn default_max_instructions() -> usize { 2000 }
+    fn default_threads() -> usize {
+        15
+    }
+    fn default_max_instructions() -> usize {
+        2000
+    }
 
     /// Load configuration from JSON file
     fn from_file(path: &PathBuf) -> Result<Self, String> {
         let content = std::fs::read_to_string(path)
             .map_err(|e| format!("Failed to read config file: {}", e))?;
-        
-        serde_json::from_str(&content)
-            .map_err(|e| format!("Failed to parse JSON config: {}", e))
+
+        serde_json::from_str(&content).map_err(|e| format!("Failed to parse JSON config: {}", e))
     }
 
     /// Create config from CLI args (for when no JSON file is provided)

--- a/src/simulation/cpu/callback.rs
+++ b/src/simulation/cpu/callback.rs
@@ -66,7 +66,6 @@ pub fn hook_custom_addresses_callback(emu: &mut Unicorn<CpuState>, address: u64,
         emu.get_data_mut().state = RunState::Failed;
         debug!("Custom failure address reached: 0x{:x}", address);
         emu.emu_stop().expect("failed to stop");
-        return;
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,7 +1,8 @@
+use assert_cmd::prelude::*;
 use fault_simulator::prelude::*;
+use predicates::prelude::*;
 use std::env;
-use std::fs;
-use std::process::Command;
+use std::process::Command; // Used for writing assertions
 
 #[test]
 /// Test for single glitch attack api
@@ -153,22 +154,14 @@ fn run_fault_simulation_two_glitches() {
 /// --config, and checks that the output contains expected values.
 /// It verifies that the config file is correctly parsed and used.
 fn test_json_config() {
-    // Create a temporary config file
-    let config = r#"{
-        "class": ["single", "glitch"],
-        "analysis": true
-    }"#;
-    fs::write("test_config.json", config).expect("Failed to write config file");
+    let mut cmd = Command::cargo_bin("fault_simulator").unwrap();
 
-    let output = Command::new("cargo")
-        .args(&["run", "--", "--config", "test_config.json"])
+    cmd.args(&["--config", "tests/test_config.json"])
         .output()
         .expect("Failed to run binary");
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Fault injection simulator"));
-    assert!(stdout.contains("glitch"));
 
-    // Clean up
-    let _ = fs::remove_file("test_config.json");
+    cmd.assert()
+        .stdout(predicate::str::contains("Fault injection simulator"))
+        .stdout(predicate::str::contains("glitch"))
+        .success();
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -153,15 +153,8 @@ fn run_fault_simulation_two_glitches() {
 /// --config, and checks that the output contains expected values.
 /// It verifies that the config file is correctly parsed and used.
 fn test_json_config() {
-    // Create a temporary config file
-    let config = r#"{
-        "class": ["single", "glitch"],
-        "analysis": true
-    }"#;
-    fs::write("test_config.json", config).expect("Failed to write config file");
-
     let output = Command::new("cargo")
-        .args(&["run", "--", "--config", "test_config.json"])
+        .args(&["run", "--", "--config", "tests/test_config.json"])
         .output()
         .expect("Failed to run binary");
     assert!(output.status.success());

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -1,0 +1,8 @@
+{
+    "elf": "tests/bin/victim_3.elf",
+    "class": [
+        "single",
+        "glitch"
+    ],
+    "analysis": true
+}

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -1,0 +1,4 @@
+{
+    "class": ["single", "glitch"],
+    "analysis": true
+}


### PR DESCRIPTION
This PR adds

- support for loading configuration from a JSON file via the --config CLI argument.
- Maintains full backward compatibility with existing CLI options.
- Updates documentation and usage examples in the README.
- Adds integration tests.

CLI arguments will overwrite values in JSON file. In the future I want to add arguments that are too complex for CLI.