### PR TITLE
Implement custom initial register values

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,31 @@ CLI arguments always override values from the config file.
    cargo run -- --faults regbf_r1_0100 glitch_1
    ```
 
-**Hex Addresses:**  
-For address fields, you can use either numbers or hex strings (e.g., `"0x08000496"`) in your JSON config.
+6. **Running with custom initial register context:**
+   Create a config file (`custom_context.json`):
+   ```json
+   {
+     "elf": "tests/bin/victim_3.elf",
+     "class": ["single", "glitch"],
+     "analysis": true,
+     "initial_registers": {
+       "R0": "0x12345678",
+       "R7": "0x2000FFF8",
+       "SP": "0x2000FFF8",
+       "LR": "0x08000005",
+       "PC": "0x08000620"
+     }
+   }
+   ```
+   Run with:
+   ```bash
+   cargo run -- --config custom_context.json
+   ```
+
+**Supported registers:** R0-R12, SP, LR, PC, CPSR  
+**Value formats:** Hex strings (`"0x12345678"`) or decimal numbers (`42`)  
+**Case insensitive:** `"r0"`, `"R0"`, `"sp"`, `"SP"` all work
+
 
 ## Ghidra Visualization
 

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -38,6 +38,7 @@ impl<'a> Control<'a> {
     /// * `decision_activation_active` - A boolean indicating whether decision activation is enabled.
     /// * `success_addresses` - List of memory addresses that indicate success when executed.
     /// * `failure_addresses` - List of memory addresses that indicate failure when executed.
+    /// * `initial_registers` - HashMap of RegisterARM to initial values for CPU registers.
     ///
     /// # Returns
     ///
@@ -47,9 +48,15 @@ impl<'a> Control<'a> {
         decision_activation_active: bool,
         success_addresses: Vec<u64>,
         failure_addresses: Vec<u64>,
+        initial_registers: std::collections::HashMap<unicorn_engine::RegisterARM, u64>,
     ) -> Self {
         // Setup cpu emulation
-        let mut emu = Cpu::new(program_data, success_addresses, failure_addresses);
+        let mut emu = Cpu::new(
+            program_data,
+            success_addresses,
+            failure_addresses,
+            initial_registers,
+        );
         // Cpu setup
         emu.setup_mmio();
         emu.setup_breakpoints(decision_activation_active);

--- a/tests/test_config.json
+++ b/tests/test_config.json
@@ -4,5 +4,11 @@
         "single",
         "glitch"
     ],
-    "analysis": true
+    "analysis": true,
+    "initial_registers": {
+        "R7": "0x2000FFF8",
+        "SP": "0x2000FFF8",
+        "LR": "0x08000005",
+        "PC": "0x8000620"
+    }
 }


### PR DESCRIPTION
This pull request allows to to set a custom context / initial values for cpu registers. This feature is only usable through the json config file.

This PR is another step toward adding the ability to test firmware files.