### PR TITLE
Implement offsets for code pachtes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ Apply binary patches to modify firmware behavior at specific addresses or symbol
       symbol: "decision_activation",
       data: "0x4770",
     },
+    // Patch at offset from symbol (symbol address + offset)
+    {
+      symbol: "check_secret",
+      offset: "0x10",
+      data: "0x2001",  // movs r0, #1
+    },
     // Replace function with bx lr (immediate return)
     {
       address: "0x08000100",
@@ -227,9 +233,10 @@ Apply binary patches to modify firmware behavior at specific addresses or symbol
 **Fields:**
 - `address` (string, optional): Memory address to patch (hex format) - use either `address` or `symbol`
 - `symbol` (string, optional): Symbol name to patch (resolved from ELF symbol table) - use either `address` or `symbol`
+- `offset` (string, optional): Hex offset to add to the symbol address (only used with `symbol`, defaults to 0)
 - `data` (string): Hex data to write at the address
 
-**Note:** Each patch must specify either `address` OR `symbol`, but not both. Using symbols makes configurations more portable across firmware versions.
+**Note:** Each patch must specify either `address` OR `symbol`, but not both. When using `symbol`, you can optionally specify an `offset` to patch at a location relative to the symbol address. Using symbols makes configurations more portable across firmware versions.
 
 #### Memory Regions
 Define custom memory regions with optional data loading from files. Essential for firmware that expects specific memory layouts (SRAM, peripherals, flash).

--- a/src/config.rs
+++ b/src/config.rs
@@ -374,6 +374,7 @@ where
     struct CodePatchHelper {
         address: Option<String>,
         symbol: Option<String>,
+        offset: Option<String>,
         data: String,
     }
 
@@ -404,6 +405,13 @@ where
                 None
             };
 
+            // Parse offset if provided
+            let offset = if let Some(offset_str) = patch.offset {
+                parse_hex(&offset_str).map_err(de::Error::custom)?
+            } else {
+                0
+            };
+
             let hex_val = parse_hex(&patch.data).map_err(de::Error::custom)?;
 
             // Convert u64 to bytes (little-endian, remove leading zeros)
@@ -421,6 +429,7 @@ where
             Ok(CodePatch {
                 address,
                 symbol: patch.symbol,
+                offset,
                 data: bytes,
             })
         })
@@ -470,6 +479,7 @@ where
 pub struct CodePatch {
     pub address: Option<u64>,
     pub symbol: Option<String>,
+    pub offset: u64,
     pub data: Vec<u8>,
 }
 

--- a/src/elf_file.rs
+++ b/src/elf_file.rs
@@ -126,7 +126,7 @@ impl ElfFile {
 
                 // Clear LSB for Thumb mode indicator - actual code is at even address
                 let mut actual_address = symbol.st_value & !1;
-                
+
                 // Add offset if provided
                 if patch.offset != 0 {
                     actual_address = actual_address.wrapping_add(patch.offset);

--- a/src/elf_file.rs
+++ b/src/elf_file.rs
@@ -125,12 +125,21 @@ impl ElfFile {
                     .ok_or_else(|| format!("Symbol '{}' not found in ELF file", sym_name))?;
 
                 // Clear LSB for Thumb mode indicator - actual code is at even address
-                let actual_address = symbol.st_value & !1;
-
-                println!(
-                    "  Resolving symbol '{}' to address 0x{:08X}",
-                    sym_name, actual_address
-                );
+                let mut actual_address = symbol.st_value & !1;
+                
+                // Add offset if provided
+                if patch.offset != 0 {
+                    actual_address = actual_address.wrapping_add(patch.offset);
+                    println!(
+                        "  Resolving symbol '{}' + 0x{:X} to address 0x{:08X}",
+                        sym_name, patch.offset, actual_address
+                    );
+                } else {
+                    println!(
+                        "  Resolving symbol '{}' to address 0x{:08X}",
+                        sym_name, actual_address
+                    );
+                }
                 actual_address
             } else if let Some(addr) = patch.address {
                 addr

--- a/tests/test_config_code_patch_symbol_offset.json5
+++ b/tests/test_config_code_patch_symbol_offset.json5
@@ -1,0 +1,17 @@
+// Test configuration for code patching by symbol name with offset
+{
+    elf: "tests/bin/test.elf",
+    class: [
+        "single",
+        "glitch",
+    ],
+    analysis: true,
+    code_patches: [
+        // Patch check_secret function at offset 0x4 from function start
+        {
+            symbol: "check_secret",
+            offset: "0x4",
+            data: "0x2001",  // movs r0, #1
+        },
+    ],
+}


### PR DESCRIPTION
This small PR implements an offset field for code patches. Could make it easier to reuse configurations after an .elf has been recompiled.