### PR TITLE
Fix virtual address mapping and add force_overwrite option for memory regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,13 @@ Define custom memory regions with optional data loading from files. Essential fo
       size: "0x1000",
       data: "0xDEADBEEF",  // Inline hex value to initialize region
     },
+    // SRAM with memory dump - force merge fragmented ELF segments
+    {
+      address: "0x34000000",
+      size: "0x10000",
+      file: "sram_dump.bin",
+      force_overwrite: true,  // Merge ELF segments to load full dump
+    },
   ],
 }
 ```
@@ -270,6 +277,7 @@ Define custom memory regions with optional data loading from files. Essential fo
 - `size` (string): Size of the region in bytes (hex format)
 - `file` (string, optional): Binary file to load into this region
 - `data` (string, optional): Hex value to initialize the region with (e.g., "0xDEADBEEF")
+- `force_overwrite` (boolean, optional, default: false): If true, merges fragmented ELF segments within this region into one contiguous block to ensure the entire region can be mapped and overwritten with custom data
 
 
 ## Ghidra Visualization

--- a/src/config.rs
+++ b/src/config.rs
@@ -449,6 +449,8 @@ where
         address: String,
         size: String,
         file: Option<String>, // Optional binary file to load
+        #[serde(default)]
+        force_overwrite: bool, // If true, merge ELF segments to allow overwriting
     }
 
     let regions: Vec<MemoryRegionHelper> = Deserialize::deserialize(deserializer)?;
@@ -470,6 +472,7 @@ where
                 address,
                 size,
                 data,
+                force_overwrite: region.force_overwrite,
             })
         })
         .collect()
@@ -488,4 +491,5 @@ pub struct MemoryRegion {
     pub address: u64,
     pub size: u64,
     pub data: Option<Vec<u8>>, // Optional: data to initialize the region with
+    pub force_overwrite: bool, // If true, merge ELF segments to allow overwriting
 }

--- a/src/elf_file.rs
+++ b/src/elf_file.rs
@@ -156,7 +156,8 @@ impl ElfFile {
             // Find which program segment contains this address
             let mut found = false;
             for (header, data) in &mut self.program_data {
-                let segment_start = header.p_paddr;
+                // Use virtual address (p_vaddr) for ARM Cortex-M flat memory model
+                let segment_start = header.p_vaddr;
                 let segment_end = segment_start + header.p_filesz;
 
                 if address >= segment_start && address < segment_end {

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -60,7 +60,7 @@ impl<'a> Control<'a> {
             initial_registers,
         );
         // Cpu setup
-        emu.setup_mmio();
+        emu.setup_mmio(memory_regions);
         emu.setup_memory_regions(memory_regions);
         emu.setup_breakpoints(decision_activation_active);
         // Write code to memory area


### PR DESCRIPTION
This PR fixes some more issues  I came across during using the simulator with elf files:

1. **Virtual address fix (p_vaddr vs p_paddr):** Changed the code to use virtual addresses instead of physical addresses so the simulator maps and executes code at the addresses where the CPU expects to find it.

2. **force_overwrite config option:** Added a config flag that, when enabled, forces the simulator to merge fragmented ELF memory segments into one contiguous block.

3. **Code hook virtual address fix:** Updated the success/failure address detection hooks to use virtual addresses so they trigger at the correct instruction locations.

4. **Code patching virtual address fix:** Changed code patching to use virtual addresses so patches are applied to the correct memory locations where code actually executes.

