### PR TITLE
Implement new success and failure condition checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,39 @@ Define custom memory regions with optional data loading from files. Essential fo
 - `data` (string, optional): Hex value to initialize the region with (e.g., "0xDEADBEEF")
 - `force_overwrite` (boolean, optional, default: false): If true, merges fragmented ELF segments within this region into one contiguous block to ensure the entire region can be mapped and overwritten with custom data
 
+#### Result Checks
+Check register values at specific addresses to determine success or failure.
+
+```json5
+{
+  result_checks: {
+    success_checks: [
+      {
+        address: "0x08000490",
+        expected_registers: {
+          R0: "0x00000000",
+        }
+      }
+    ],
+    failure_checks: [
+      {
+        address: "0x08000490",
+        expected_registers: {
+          R0: "0xFFFFFFFF",
+        }
+      }
+    ]
+  }
+}
+```
+
+- `success_checks`: Conditions that indicate a successful attack
+- `failure_checks`: Conditions that indicate expected secure behavior
+- `address`: Where to check (hex format)
+- `expected_registers`: Register values that must match (supports R0-R12, SP, LR, PC, CPSR)
+
+All specified registers must match for the check to trigger. If `result_checks` is set, it takes precedence over `success_addresses` and `failure_addresses`.
+
 
 ## Ghidra Visualization
 

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -23,6 +23,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 std::collections::HashMap::new(), // initial_registers
                 vec![],                           // memory_regions
                 "info".to_string(),               // log_level
+                None,                             // result_checks
             ),
             &file_data,
             cpu_cores,

--- a/src/config.rs
+++ b/src/config.rs
@@ -221,6 +221,8 @@ pub struct Config {
     pub memory_regions: Vec<MemoryRegion>,
     #[serde(default)]
     pub log_level: String,
+    #[serde(default)]
+    pub result_checks: Option<ResultChecks>,
 }
 
 impl Config {
@@ -276,6 +278,7 @@ impl Config {
             code_patches: Vec::new(),
             memory_regions: Vec::new(),
             log_level: "off".to_string(),
+            result_checks: None,
         }
     }
 
@@ -536,6 +539,39 @@ where
         .collect()
 }
 
+/// Deserialize a single hex string to u64
+fn deserialize_single_hex<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::{self, Visitor};
+
+    struct HexVisitor;
+
+    impl<'de> Visitor<'de> for HexVisitor {
+        type Value = u64;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a hex string (e.g., '0x1234') or a number")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<u64, E>
+        where
+            E: de::Error,
+        {
+            parse_hex(value).map_err(de::Error::custom)
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<u64, E>
+        where
+            E: de::Error,
+        {
+            Ok(value)
+        }
+    }
+
+    deserializer.deserialize_any(HexVisitor)
+}
 #[derive(Debug, Clone)]
 pub struct CodePatch {
     pub address: Option<u64>,
@@ -552,6 +588,27 @@ pub struct MemoryRegion {
     pub force_overwrite: bool, // If true, merge ELF segments to allow overwriting
 }
 
+/// Configuration for register value checking at a specific address
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegisterCheck {
+    /// Address where register values should be checked
+    #[serde(deserialize_with = "deserialize_single_hex")]
+    pub address: u64,
+    /// Expected register values (e.g., {"R0": "0x00000001", "R1": "0x00000000"})
+    #[serde(deserialize_with = "deserialize_register_context")]
+    pub expected_registers: HashMap<RegisterARM, u64>,
+}
+
+/// Configuration for register-based success/failure checking
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResultChecks {
+    /// List of register checks that indicate success
+    #[serde(default)]
+    pub success_checks: Vec<RegisterCheck>,
+    /// List of register checks that indicate failure
+    #[serde(default)]
+    pub failure_checks: Vec<RegisterCheck>,
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/fault_attacks/mod.rs
+++ b/src/fault_attacks/mod.rs
@@ -428,6 +428,7 @@ impl FaultAttacks {
             self.user_thread.config.failure_addresses.clone(),
             self.user_thread.config.initial_registers.clone(),
             &self.user_thread.config.memory_regions,
+            self.user_thread.config.result_checks.clone(),
         );
         simulation.check_program(self.user_thread.config.cycles)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub mod simulation_thread;
 /// * Fault types: All fault implementations (glitch, register operations, etc.)
 /// * Simulation core: `SimulationThread`, `WorkloadMessage`, `TraceRecord`
 pub mod prelude {
-    pub use crate::config::{CodePatch, Config, MemoryRegion};
+    pub use crate::config::{CodePatch, Config, MemoryRegion, RegisterCheck, ResultChecks};
     pub use crate::elf_file::*;
     pub use crate::error::SimulatorError;
     pub use crate::fault_attack_thread::FaultAttackThread;

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,7 @@ fn main() -> Result<(), SimulatorError> {
         config.initial_registers,
         config.memory_regions,
         config.log_level.clone(),
+        config.result_checks,
     );
     // Create user thread for simulation
     let user_thread = Arc::new(SimulationThread::new_with_threads(

--- a/src/simulation/cpu/mod.rs
+++ b/src/simulation/cpu/mod.rs
@@ -28,7 +28,8 @@ mod callback;
 
 use callback::{
     capture_memory_errors, hook_code_callback, hook_code_decision_activation_callback,
-    hook_custom_addresses_callback, mmio_auth_write_callback, mmio_serial_write_callback,
+    hook_custom_addresses_callback, hook_result_check_callback, mmio_auth_write_callback,
+    mmio_serial_write_callback,
 };
 
 use unicorn_engine::unicorn_const::uc_error;
@@ -124,6 +125,7 @@ struct CpuState<'a> {
     file_data: &'a ElfFile,
     success_addresses: Vec<u64>,
     failure_addresses: Vec<u64>,
+    result_checks: Option<crate::config::ResultChecks>,
 }
 
 impl<'a> Cpu<'a> {
@@ -135,6 +137,7 @@ impl<'a> Cpu<'a> {
     /// * `success_addresses` - List of memory addresses that indicate success when executed.
     /// * `failure_addresses` - List of memory addresses that indicate failure when executed.
     /// * `initial_registers` - HashMap of RegisterARM to initial values.
+    /// * `result_checks` - Register-based success/failure checking configuration.
     ///
     /// # Returns
     ///
@@ -144,6 +147,7 @@ impl<'a> Cpu<'a> {
         success_addresses: Vec<u64>,
         failure_addresses: Vec<u64>,
         initial_registers: HashMap<RegisterARM, u64>,
+        result_checks: Option<crate::config::ResultChecks>,
     ) -> Self {
         // Setup platform -> ARMv8-m.base
         let emu = Unicorn::new_with_data(
@@ -160,6 +164,7 @@ impl<'a> Cpu<'a> {
                 file_data,
                 success_addresses,
                 failure_addresses,
+                result_checks,
             },
         )
         .expect("failed to initialize Unicorn instance");
@@ -281,11 +286,27 @@ impl<'a> Cpu<'a> {
         }
 
         // Set up code hooks for custom success/failure addresses (if any provided)
+        // Priority: result_checks > custom addresses > MMIO-based checking
+        let has_result_checks = self.emu.get_data().result_checks.is_some();
         let has_custom_addresses = !self.emu.get_data().success_addresses.is_empty()
             || !self.emu.get_data().failure_addresses.is_empty();
-        if has_custom_addresses {
-            // Add code hook for all program segments to check for custom addresses
-            // Use virtual addresses (p_vaddr) for ARM Cortex-M flat memory model
+
+        if has_result_checks {
+            // Use register-based checking (new mechanism)
+            debug!("Using register-based success/failure checking");
+            let program_data = &self.emu.get_data().file_data.program_data.clone();
+            for segment in program_data {
+                self.emu
+                    .add_code_hook(
+                        segment.0.p_vaddr,
+                        segment.0.p_vaddr + segment.0.p_memsz,
+                        hook_result_check_callback,
+                    )
+                    .expect("failed to set result check code hook");
+            }
+        } else if has_custom_addresses {
+            // Use address-based checking (backward compatibility)
+            debug!("Using address-based success/failure checking");
             let program_data = &self.emu.get_data().file_data.program_data.clone();
             for segment in program_data {
                 self.emu
@@ -297,7 +318,8 @@ impl<'a> Cpu<'a> {
                     .expect("failed to set custom address code hook");
             }
         } else {
-            // Only set up the MMIO hook when NOT using custom addresses
+            // Only set up the MMIO hook when NOT using custom addresses or result checks
+            debug!("Using MMIO-based success/failure checking");
             self.emu
                 .add_mem_hook(
                     HookType::MEM_WRITE,

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -116,6 +116,8 @@ impl<'a> Control<'a> {
     /// * `success_addresses` - List of memory addresses that indicate success when executed.
     /// * `failure_addresses` - List of memory addresses that indicate failure when executed.
     /// * `initial_registers` - HashMap of RegisterARM to initial values for CPU registers.
+    /// * `memory_regions` - Custom memory regions to initialize.
+    /// * `result_checks` - Register-based success/failure checking configuration.
     ///
     /// # Returns
     ///
@@ -127,6 +129,7 @@ impl<'a> Control<'a> {
         failure_addresses: Vec<u64>,
         initial_registers: std::collections::HashMap<unicorn_engine::RegisterARM, u64>,
         memory_regions: &[crate::config::MemoryRegion],
+        result_checks: Option<crate::config::ResultChecks>,
     ) -> Self {
         // Setup cpu emulation
         let mut emu = Cpu::new(
@@ -134,6 +137,7 @@ impl<'a> Control<'a> {
             success_addresses,
             failure_addresses,
             initial_registers,
+            result_checks,
         );
         // Cpu setup
         emu.setup_mmio(memory_regions);

--- a/src/simulation_thread.rs
+++ b/src/simulation_thread.rs
@@ -317,7 +317,7 @@ impl SimulationThread {
             initial_registers,
             Vec::new(),        // No memory regions in this test
             "off".to_string(), // Default verbose level
-            None,               // No result checks
+            None,              // No result checks
         );
         Self::new(config)
     }

--- a/src/simulation_thread.rs
+++ b/src/simulation_thread.rs
@@ -73,6 +73,8 @@ pub struct SimulationConfig {
     pub memory_regions: Vec<crate::config::MemoryRegion>,
     /// Log level: "off", "error", "warn", "info", "debug", "trace".
     pub log_level: String,
+    /// Register-based success/failure checking configuration.
+    pub result_checks: Option<crate::config::ResultChecks>,
 }
 
 impl SimulationConfig {
@@ -87,6 +89,7 @@ impl SimulationConfig {
     /// * `initial_registers` - Initial CPU register values to set before each simulation.
     /// * `memory_regions` - Custom memory regions to initialize.
     /// * `log_level` - Log level: "off", "error", "warn", "info", "debug", "trace".
+    /// * `result_checks` - Register-based success/failure checking configuration.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         cycles: usize,
@@ -96,6 +99,7 @@ impl SimulationConfig {
         initial_registers: std::collections::HashMap<unicorn_engine::RegisterARM, u64>,
         memory_regions: Vec<crate::config::MemoryRegion>,
         log_level: String,
+        result_checks: Option<crate::config::ResultChecks>,
     ) -> Self {
         Self {
             cycles,
@@ -105,6 +109,7 @@ impl SimulationConfig {
             initial_registers,
             memory_regions,
             log_level,
+            result_checks,
         }
     }
 }
@@ -312,6 +317,7 @@ impl SimulationThread {
             initial_registers,
             Vec::new(),        // No memory regions in this test
             "off".to_string(), // Default verbose level
+            None,               // No result checks
         );
         Self::new(config)
     }
@@ -381,6 +387,7 @@ impl SimulationThread {
             let failure_addrs = self.config.failure_addresses.clone();
             let init_regs = self.config.initial_registers.clone();
             let mem_regions = self.config.memory_regions.clone();
+            let result_checks = self.config.result_checks.clone();
             let cycles = self.config.cycles;
             let handle = spawn(move || {
                 // Wait for workload
@@ -392,6 +399,7 @@ impl SimulationThread {
                     failure_addrs.clone(),
                     init_regs.clone(),
                     &mem_regions,
+                    result_checks.clone(),
                 );
                 // Create a separate simulation instance for trace recordings (reused)
                 let mut trace_simulation = Control::new(
@@ -401,6 +409,7 @@ impl SimulationThread {
                     failure_addrs.clone(),
                     init_regs.clone(),
                     &mem_regions,
+                    result_checks.clone(),
                 );
                 // Loop until the workload receiver is closed
                 while let Ok(msg) = receiver.recv() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -31,6 +31,7 @@ fn run_single_glitch() {
                 std::collections::HashMap::new(),
                 vec![],
                 "info".to_string(),
+                None,
             ),
             &file_data,
             cpu_cores,
@@ -55,6 +56,7 @@ fn run_single_glitch() {
                 std::collections::HashMap::new(),
                 vec![],
                 "info".to_string(),
+                None,
             ),
             &file_data,
             cpu_cores,
@@ -82,6 +84,7 @@ fn run_single_glitch() {
                 std::collections::HashMap::new(),
                 vec![],
                 "info".to_string(),
+                None,
             ),
             &file_data,
             cpu_cores,
@@ -117,6 +120,7 @@ fn run_double_glitch() {
                 std::collections::HashMap::new(), // initial_registers
                 vec![],
                 "info".to_string(),
+                None,
             ),
             &file_data,
             fixed_threads,
@@ -158,6 +162,7 @@ fn run_fault_simulation_one_glitch() {
                 std::collections::HashMap::new(), // initial_registers
                 vec![],
                 "info".to_string(),
+                None,
             ),
             &file_data,
             cpu_cores,
@@ -265,6 +270,7 @@ fn test_success_and_failure_addresses() {
                 std::collections::HashMap::new(), // initial_registers
                 vec![],
                 "info".to_string(),
+                None,
             ),
             &file_data,
             cpu_cores,
@@ -343,6 +349,7 @@ fn test_initial_register_context() {
                 initial_registers,
                 vec![],
                 "info".to_string(),
+                None,
             ),
             &file_data,
             cpu_cores,
@@ -462,5 +469,92 @@ fn test_code_victim_5_full_run() {
     // Should run without Unicorn error and execute all tests (711064 total iterations)
     cmd.assert()
         .stdout(predicate::str::contains("Overall tests executed 711064"))
+        .success();
+}
+
+#[test]
+/// Test for result_checks functionality
+///
+/// This test verifies the new result_checks mechanism that checks both address
+/// and register values. It uses victim_3.elf and defines checkpoints where specific
+/// register values determine success or failure.
+fn test_result_checks() {
+    use unicorn_engine::RegisterARM;
+
+    let cpu_cores = get_cpu_cores();
+
+    // Create result checks configuration
+    let success_check = RegisterCheck {
+        address: 0x08000490,
+        expected_registers: {
+            let mut map = std::collections::HashMap::new();
+            map.insert(RegisterARM::R0, 0x00000000);
+            map
+        },
+    };
+
+    let failure_check_1 = RegisterCheck {
+        address: 0x08000490,
+        expected_registers: {
+            let mut map = std::collections::HashMap::new();
+            map.insert(RegisterARM::R0, 0x00000001);
+            map
+        },
+    };
+
+    let result_checks = ResultChecks {
+        success_checks: vec![success_check],
+        failure_checks: vec![failure_check_1],
+    };
+
+    let file_data: ElfFile =
+        ElfFile::new(std::path::PathBuf::from("tests/bin/victim_3.elf")).unwrap();
+
+    let sim_config = SimulationConfig::new(
+        2000,
+        false,
+        vec![],
+        vec![],
+        std::collections::HashMap::new(),
+        vec![],
+        "off".to_string(),
+        Some(result_checks),
+    );
+
+    let user_thread = std::sync::Arc::new(
+        SimulationThread::new_with_threads(sim_config, &file_data, cpu_cores).unwrap(),
+    );
+    let mut attack = FaultAttacks::new_with_threads(&file_data, user_thread, cpu_cores).unwrap();
+
+    // Test single glitch attack with result_checks
+    let vec = ["glitch".to_string()];
+    let single_result = attack.single(&vec, false).unwrap();
+
+    assert!(
+        single_result.1 > 0,
+        "Expected some attack iterations with result_checks"
+    );
+}
+
+#[test]
+/// Integration test for result_checks from JSON5 config
+///
+/// This test verifies that result_checks can be loaded from a JSON5 config file
+/// and used in simulation.
+fn test_result_checks_json_config() {
+    let mut cmd = Command::cargo_bin("fault_simulator").unwrap();
+
+    cmd.args([
+        "--config",
+        "tests/test_config_result_checks.json5",
+        "--no-check",
+        "--max-instructions",
+        "100",
+    ]);
+
+    cmd.assert()
+        .stderr(predicate::str::contains(
+            "Using register-based success/failure checking",
+        ))
         .success();
 }

--- a/tests/test_config_result_checks.json5
+++ b/tests/test_config_result_checks.json5
@@ -1,0 +1,31 @@
+// Test configuration for result_checks feature
+{
+    elf: "tests/bin/victim_3.elf",
+    class: [
+        "single",
+        "glitch",
+    ],
+    analysis: true,
+    max_instructions: 100,
+    log_level: "debug",
+    
+    // New result_checks mechanism
+    result_checks: {
+        success_checks: [
+            {
+                address: "0x08000490",
+                expected_registers: {
+                    R0: "0x00000000",  // R0 = 0 means success
+                }
+            }
+        ],
+        failure_checks: [
+            {
+                address: "0x08000490",
+                expected_registers: {
+                    R0: "0x00000001",  // R0 = 1 means failure
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Register-Based Success/Failure Checking

Adds support for checking register values at specific addresses instead of just checking if an address is reached.

Some functions don't have separate success/failure code paths. For example, a  function might return different values in R0 (0 for success, -1 for failure) but always reaches the same return address.

The new `result_checks` configuration option that checks both address AND register values:

```json5
{
  result_checks: {
    success_checks: [
      { address: "0x08000490", expected_registers: { R0: "0x00000000" } }
    ],
    failure_checks: [
      { address: "0x08000490", expected_registers: { R0: "0xFFFFFFFF" } }
    ]
  }
}
```

It is still backward compatible with `s uccess_addresses and failure_addresses`.

This is still experimental and Im not sure if it breaks something or has logical issues. Therefore I wanna leave it as draft for now